### PR TITLE
Add color to output messages 🌈

### DIFF
--- a/cmd/inclusify/main.go
+++ b/cmd/inclusify/main.go
@@ -11,12 +11,13 @@ import (
 	"github.com/hashicorp/inclusify/pkg/files"
 	"github.com/hashicorp/inclusify/pkg/gh"
 	"github.com/hashicorp/inclusify/pkg/pulls"
+	"github.com/hashicorp/inclusify/pkg/message"
 	"github.com/hashicorp/inclusify/pkg/version"
 )
 
 func main() {
 	if err := inner(); err != nil {
-		log.Printf("inclusify error: %s\n", err)
+		log.Printf("%s: %s\n", message.Error("inclusify error"), err)
 		os.Exit(1)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.15
 
 require (
 	github.com/dchest/uniuri v0.0.0-20200228104902-7aecb25e1fe5
+	github.com/fatih/color v1.9.0
 	github.com/go-git/go-git/v5 v5.1.0
 	github.com/google/go-github v17.0.0+incompatible
 	github.com/google/go-github/v32 v32.1.0

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,8 @@ github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=
+github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568 h1:BHsljHzVlRcyQhjrss6TZTdY2VfCqZPbv5k3iBFa2ZQ=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/gliderlabs/ssh v0.2.2 h1:6zsha5zo/TWhRhwqCD3+EarCAgZ2yN28ipRnGPnwkI0=
@@ -69,6 +71,8 @@ github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNx
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.10 h1:qxFzApOv4WsAL965uUPIsXzAKCZxN2p9UqdhFS4ZW10=
 github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcMEpPG5Rm84=
+github.com/mattn/go-isatty v0.0.11 h1:FxPOTFNqGkuDUGi3H/qkUbQO4ZiBa2brKq5r0l8TGeM=
+github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOAqxQCu2WE=
 github.com/mitchellh/cli v1.1.1 h1:J64v/xD7Clql+JVKSvkYojLOXu1ibnY9ZjGLwSt/89w=
 github.com/mitchellh/cli v1.1.1/go.mod h1:xcISNoH86gajksDmfB23e/pu+B+GeFRMYmoHXxx3xhI=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
@@ -120,6 +124,7 @@ golang.org/x/sys v0.0.0-20190221075227-b4e8571b14e0/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527 h1:uYVVQ9WP/Ds2ROhcaGPeIdVq0RIXVLwsHlnvJ+cT1So=
 golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/pkg/branches/create.go
+++ b/pkg/branches/create.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/inclusify/pkg/config"
 	"github.com/hashicorp/inclusify/pkg/gh"
+	"github.com/hashicorp/inclusify/pkg/message"
 )
 
 // CreateCommand is a struct used to configure a Command for creating new
@@ -29,7 +30,7 @@ func (c *CreateCommand) Run(args []string) int {
 	c.BranchesList = append(c.BranchesList, c.Config.Target)
 	for _, branch := range c.BranchesList {
 		c.Config.Logger.Info(fmt.Sprintf(
-			"Creating new branch %s off of %s", branch, c.Config.Base,
+			message.Info("Creating new branch %s off of %s"), branch, c.Config.Base,
 		))
 		refName := fmt.Sprintf("refs/heads/%s", c.Config.Base)
 		ref, _, err := c.GithubClient.GetGit().GetRef(ctx, c.Config.Owner, c.Config.Repo, refName)
@@ -52,7 +53,7 @@ func (c *CreateCommand) Run(args []string) int {
 		}
 	}
 
-	c.Config.Logger.Info("Success!")
+	c.Config.Logger.Info(message.Success("Success!"))
 
 	return 0
 }
@@ -60,7 +61,7 @@ func (c *CreateCommand) Run(args []string) int {
 // exitError prints the error to the configured UI Error channel (usually stderr) then
 // returns the exit code.
 func (c *CreateCommand) exitError(err error) int {
-	c.Config.Logger.Error(err.Error())
+	c.Config.Logger.Error(message.Error(err.Error()))
 	return 1
 }
 

--- a/pkg/branches/delete.go
+++ b/pkg/branches/delete.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/inclusify/pkg/config"
 	"github.com/hashicorp/inclusify/pkg/gh"
+	"github.com/hashicorp/inclusify/pkg/message"
 )
 
 // DeleteCommand is a struct used to configure a Command for deleting the
@@ -42,7 +43,7 @@ func (c *DeleteCommand) Run(args []string) int {
 			c.Config.Logger.Info("Failed to delete ref", "branch", branch, "error", err)
 		}
 
-		c.Config.Logger.Info("Success! branch has been deleted", "branch", branch, "ref", refName)
+		c.Config.Logger.Info(message.Success("Success! branch has been deleted"), "branch", branch, "ref", refName)
 	}
 
 	return 0

--- a/pkg/branches/updateDefault.go
+++ b/pkg/branches/updateDefault.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/inclusify/pkg/config"
 	"github.com/hashicorp/inclusify/pkg/gh"
+	"github.com/hashicorp/inclusify/pkg/message"
 )
 
 // UpdateCommand is a struct used to configure a Command for updating
@@ -150,7 +151,7 @@ func (c *UpdateCommand) Run(args []string) int {
 		return c.exitError(err)
 	}
 
-	c.Config.Logger.Info("Success!")
+	c.Config.Logger.Info(message.Success("Success!"))
 
 	return 0
 }
@@ -158,7 +159,7 @@ func (c *UpdateCommand) Run(args []string) int {
 // exitError prints the error to the configured UI Error channel (usually stderr) then
 // returns the exit code.
 func (c *UpdateCommand) exitError(err error) int {
-	c.Config.Logger.Error(err.Error())
+	c.Config.Logger.Error(message.Error(err.Error()))
 	return 1
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	hclog "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/inclusify/pkg/message"
 	"github.com/mitchellh/cli"
 	nflag "github.com/namsral/flag"
 )
@@ -64,7 +65,10 @@ func ParseAndValidate(args []string, ui cli.Ui) (c *Config, err error) {
 	}
 
 	if owner == "" || repo == "" || token == "" {
-		return c, fmt.Errorf("required inputs are missing\nPass in all required flags or set env vars with the prefix INCLUSIFY\nRun [subcommand] --help to view required inputs")
+		return c, fmt.Errorf(
+			"%s\nPass in all required flags or set environment variables with the 'INCLUSIFY_' prefix.\nRun [subcommand] --help to view required inputs.",
+			message.Error("required inputs are missing"),
+		)
 	}
 
 	if len(exclusion) > 0 {

--- a/pkg/files/createScaffold.go
+++ b/pkg/files/createScaffold.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/go-github/v32/github"
 	"github.com/hashicorp/inclusify/pkg/config"
 	"github.com/hashicorp/inclusify/pkg/gh"
+	"github.com/hashicorp/inclusify/pkg/message"
 	"github.com/otiai10/copy"
 
 	git "github.com/go-git/go-git/v5"
@@ -190,6 +191,6 @@ func (c *CreateScaffoldCommand) Run(args []string) int {
 // exitError prints the error to the configured UI Error channel (usually stderr) then
 // returns the exit code.
 func (c *CreateScaffoldCommand) exitError(err error) int {
-	c.Config.Logger.Error(err.Error())
+	c.Config.Logger.Error(message.Error(err.Error()))
 	return 1
 }

--- a/pkg/files/updateRefs.go
+++ b/pkg/files/updateRefs.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/hashicorp/inclusify/pkg/config"
 	"github.com/hashicorp/inclusify/pkg/gh"
+	"github.com/hashicorp/inclusify/pkg/message"
 )
 
 // UpdateRefsCommand is a struct used to configure a Command for updating
@@ -56,7 +57,7 @@ func CloneRepo(c *UpdateRefsCommand) (repoRef *git.Repository, dir string, err e
 		return nil, "", fmt.Errorf("failed to clone repo %s %s %w", url, refName, err)
 	}
 
-	c.Config.Logger.Info("Successfully cloned repo into local dir", "repo", c.Config.Repo, "dir", dir)
+	c.Config.Logger.Info(message.Success("Successfully cloned repo into local dir"), "repo", c.Config.Repo, "dir", dir)
 
 	return repo, dir, nil
 }
@@ -169,12 +170,12 @@ func OpenPull(c *UpdateRefsCommand, tmpBranch string) (err error) {
 		MaintainerCanModify: &modify,
 	}
 
-	c.Config.Logger.Info("Creating PR to merge changes from branch into target", "branch", tmpBranch, "target", c.Config.Target)
+	c.Config.Logger.Info(message.Info("Creating PR to merge changes from branch into target"), "branch", tmpBranch, "target", c.Config.Target)
 	pr, _, err := c.GithubClient.GetPRs().Create(ctx, c.Config.Owner, c.Config.Repo, pull)
 	if err != nil {
 		return fmt.Errorf("failed to open PR: %w", err)
 	}
-	c.Config.Logger.Info("Success! Review and merge the open PR", "url", pr.GetHTMLURL())
+	c.Config.Logger.Info(message.Success("Success! Review and merge the open PR"), "url", pr.GetHTMLURL())
 
 	return nil
 }
@@ -200,7 +201,7 @@ func (c *UpdateRefsCommand) Run(args []string) int {
 
 	// Exit if no files were modified during the find and replace
 	if !filesChanged {
-		c.Config.Logger.Info("Exiting -- No CI files contained base, so there's nothing more to do", "base", c.Config.Base)
+		c.Config.Logger.Info(message.Info("Exiting -- No CI files contained base, so there's nothing more to do"), "base", c.Config.Base)
 		return 0
 	}
 
@@ -222,7 +223,7 @@ func (c *UpdateRefsCommand) Run(args []string) int {
 // exitError prints the error to the configured UI Error channel (usually stderr) then
 // returns the exit code.
 func (c *UpdateRefsCommand) exitError(err error) int {
-	c.Config.Logger.Error(err.Error())
+	c.Config.Logger.Error(message.Error(err.Error()))
 	return 1
 }
 

--- a/pkg/message/message.go
+++ b/pkg/message/message.go
@@ -1,0 +1,21 @@
+package message
+
+import (
+	"github.com/fatih/color"
+)
+
+func Error(s string) string {
+	return color.RedString(s)
+}
+
+func Success(s string) string {
+	return color.GreenString(s)
+}
+
+func Warn(s string) string {
+	return color.YellowString(s)
+}
+
+func Info(s string) string {
+	return color.CyanString(s)
+}

--- a/pkg/pulls/close.go
+++ b/pkg/pulls/close.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/inclusify/pkg/config"
 	"github.com/hashicorp/inclusify/pkg/gh"
+	"github.com/hashicorp/inclusify/pkg/message"
 )
 
 // CloseCommand is a struct used to configure a Command for closing an open PR
@@ -28,7 +29,7 @@ func (c *CloseCommand) Run(args []string) int {
 		return c.exitError(err)
 	}
 
-	c.Config.Logger.Info("Successfully closed PR", "number", c.PullNumber)
+	c.Config.Logger.Info(message.Success("Successfully closed PR"), "number", c.PullNumber)
 
 	return 0
 }
@@ -36,6 +37,6 @@ func (c *CloseCommand) Run(args []string) int {
 // exitError prints the error to the configured UI Error channel (usually stderr) then
 // returns the exit code.
 func (c *CloseCommand) exitError(err error) int {
-	c.Config.Logger.Error(err.Error())
+	c.Config.Logger.Error(message.Error(err.Error()))
 	return 1
 }

--- a/pkg/pulls/merge.go
+++ b/pkg/pulls/merge.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/inclusify/pkg/config"
 	"github.com/hashicorp/inclusify/pkg/gh"
+	"github.com/hashicorp/inclusify/pkg/message"
 )
 
 // MergeCommand is a struct used to configure a Command for merging an open PR
@@ -32,7 +33,7 @@ func (c *MergeCommand) Run(args []string) int {
 		return c.exitError(errors.New("failed to merge PR"))
 	}
 
-	c.Config.Logger.Info("Successfully merged PR", "number", c.PullNumber)
+	c.Config.Logger.Info(message.Success("Successfully merged PR"), "number", c.PullNumber)
 
 	return 0
 }
@@ -40,6 +41,6 @@ func (c *MergeCommand) Run(args []string) int {
 // exitError prints the error to the configured UI Error channel (usually stderr) then
 // returns the exit code.
 func (c *MergeCommand) exitError(err error) int {
-	c.Config.Logger.Error(err.Error())
+	c.Config.Logger.Error(message.Error(err.Error()))
 	return 1
 }

--- a/pkg/pulls/update.go
+++ b/pkg/pulls/update.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/go-github/v32/github"
 	"github.com/hashicorp/inclusify/pkg/config"
 	"github.com/hashicorp/inclusify/pkg/gh"
+	"github.com/hashicorp/inclusify/pkg/message"
 )
 
 // UpdateCommand is a struct used to configure a Command for updating open
@@ -92,7 +93,7 @@ func (c *UpdateCommand) Run(args []string) int {
 		return c.exitError(err)
 	}
 	if len(pulls) == 0 {
-		c.Config.Logger.Info("Exiting -- There are no open PR's to update")
+		c.Config.Logger.Info(message.Info("Exiting -- There are no open PR's to update"))
 		return 0
 	}
 
@@ -108,7 +109,7 @@ func (c *UpdateCommand) Run(args []string) int {
 		return c.exitError(err)
 	}
 
-	c.Config.Logger.Info("Success!")
+	c.Config.Logger.Info(message.Success("Success!"))
 
 	return 0
 }
@@ -116,7 +117,7 @@ func (c *UpdateCommand) Run(args []string) int {
 // exitError prints the error to the configured UI Error channel (usually stderr) then
 // returns the exit code.
 func (c *UpdateCommand) exitError(err error) int {
-	c.Config.Logger.Error(err.Error())
+	c.Config.Logger.Error(message.Error(err.Error()))
 	return 1
 }
 

--- a/pkg/repos/create.go
+++ b/pkg/repos/create.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/go-github/v32/github"
 	"github.com/hashicorp/inclusify/pkg/config"
 	"github.com/hashicorp/inclusify/pkg/gh"
+	"github.com/hashicorp/inclusify/pkg/message"
 )
 
 // CreateCommand is a struct used to configure a Command for creating a
@@ -32,7 +33,7 @@ func (c *CreateCommand) Run(args []string) int {
 		return c.exitError(fmt.Errorf("call to create repo returned error: %w", err))
 	}
 
-	c.Config.Logger.Info("Successfully created new repo", "repo", repo.GetName(), "url", repo.GetHTMLURL())
+	c.Config.Logger.Info(message.Success("Successfully created new repo"), "repo", repo.GetName(), "url", repo.GetHTMLURL())
 
 	return 0
 }
@@ -40,6 +41,6 @@ func (c *CreateCommand) Run(args []string) int {
 // exitError prints the error to the configured UI Error channel (usually stderr) then
 // returns the exit code.
 func (c *CreateCommand) exitError(err error) int {
-	c.Config.Logger.Error(err.Error())
+	c.Config.Logger.Error(message.Error(err.Error()))
 	return 1
 }

--- a/pkg/repos/delete.go
+++ b/pkg/repos/delete.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/inclusify/pkg/config"
 	"github.com/hashicorp/inclusify/pkg/gh"
+	"github.com/hashicorp/inclusify/pkg/message"
 )
 
 // DeleteCommand is a struct used to configure a Command for deleting a
@@ -29,7 +30,7 @@ func (c *DeleteCommand) Run(args []string) int {
 		return c.exitError(fmt.Errorf("call to delete repo returned error: %w", err))
 	}
 
-	c.Config.Logger.Info("Successfully deleted repo", "repo", c.Repo)
+	c.Config.Logger.Info(message.Success("Successfully deleted repo"), "repo", c.Repo)
 
 	return 0
 }
@@ -37,6 +38,6 @@ func (c *DeleteCommand) Run(args []string) int {
 // exitError prints the error to the configured UI Error channel (usually stderr) then
 // returns the exit code.
 func (c *DeleteCommand) exitError(err error) int {
-	c.Config.Logger.Error(err.Error())
+	c.Config.Logger.Error(message.Error(err.Error()))
 	return 1
 }


### PR DESCRIPTION
Closes https://github.com/hashicorp/inclusify/issues/11

This pull request adds a bit of color to the output messages:

![image](https://user-images.githubusercontent.com/8457808/95407734-d5121180-08eb-11eb-8034-2b81a1a9b1cd.png)

In the case of a failure, the output is red:

![image](https://user-images.githubusercontent.com/8457808/95407791-08ed3700-08ec-11eb-9127-548dedb8a75f.png)

@mdeggies 
