### PR TITLE
CI: Add basic build workflow to run branch pushes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,12 +1,12 @@
-name: Release
+name: Build
 
 on:
   push:
-    tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+*'
+    branches-ignore:
+      - main
 
 jobs:
-  release:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -15,15 +15,6 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: '^1.15'
-      - name: Install hc-codesign
-        id: codesign
-        run: |
-          docker login docker.pkg.github.com -u docker -p $GITHUB_TOKEN && \
-          docker pull docker.pkg.github.com/hashicorp/hc-codesign/hc-codesign:$VERSION && \
-          echo "::set-output name=image::docker.pkg.github.com/hashicorp/hc-codesign/hc-codesign:$VERSION"
-        env:
-          VERSION: v0
-          GITHUB_TOKEN: ${{ secrets.CODESIGN_GITHUB_TOKEN }}
       - name: Install wget & clamAV antivirus scanner
         run : |
            sudo apt-get -qq install -y ca-certificates wget clamav
@@ -40,15 +31,11 @@ jobs:
         env: 
           VERSION: 1.6.4
           SHA256SUM: 3ad66eebd443d32dd6c811dcf2d264b78678c75ed1d40c15434180d4453e60d2
-      - name: Import PGP key for archive signing
-        run: echo -e "$PGP_KEY" | gpg --import
-        env:
-          PGP_KEY: ${{ secrets.PGP_SIGNING_KEY }}
       - name: GitHub Release
         uses: goreleaser/goreleaser-action@v1
         with:
           version: latest
-          args: release --skip-validate --timeout "60m" --config release.goreleaser.yml
+          args: release --skip-validate --skip-sign --skip-publish --timeout "60m" --config build.goreleaser.yml
         env:
           PGP_KEY_ID: ${{ secrets.PGP_KEY_ID }}
           CODESIGN_IMAGE: ${{ steps.codesign.outputs.image }}
@@ -56,6 +43,14 @@ jobs:
           ARTIFACTORY_TOKEN: ${{ secrets.ARTIFACTORY_TOKEN }}
           ARTIFACTORY_USER: ${{ secrets.ARTIFACTORY_USER }}
           CIRCLE_TOKEN: ${{ secrets.CIRCLE_TOKEN }}
+      - name: Upload artifacts to actions workflow
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ github.event.repository.name }}-artifacts
+          path: |
+            ${{ github.workspace }}/dist/*.zip
+            ${{ github.workspace }}/dist/*.sig
+            ${{ github.workspace }}/dist/*SHA256
       - name: Run clamAV antivirus scanner
         run: sudo clamscan ${{ github.workspace }}/dist/
       - name: Run maldet malware scanner

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,34 +15,11 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: '^1.15'
-      - name: Install wget & clamAV antivirus scanner
-        run : |
-           sudo apt-get -qq install -y ca-certificates wget clamav
-           wget --version
-      - name: Install maldet malware scanner
-        run: |
-          wget --no-verbose -O maldet-$VERSION.tar.gz https://github.com/rfxn/linux-malware-detect/archive/$VERSION.tar.gz
-          sha256sum -c - <<< "$SHA256SUM  maldet-$VERSION.tar.gz"
-          sudo mkdir -p maldet-$VERSION
-          sudo tar -xzf maldet-$VERSION.tar.gz --strip-components=1 -C maldet-$VERSION
-          cd maldet-$VERSION
-          sudo ./install.sh
-          sudo maldet -u
-        env: 
-          VERSION: 1.6.4
-          SHA256SUM: 3ad66eebd443d32dd6c811dcf2d264b78678c75ed1d40c15434180d4453e60d2
       - name: GitHub Release
         uses: goreleaser/goreleaser-action@v1
         with:
           version: latest
           args: release --skip-validate --skip-sign --skip-publish --timeout "60m" --config build.goreleaser.yml
-        env:
-          PGP_KEY_ID: ${{ secrets.PGP_KEY_ID }}
-          CODESIGN_IMAGE: ${{ steps.codesign.outputs.image }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ARTIFACTORY_TOKEN: ${{ secrets.ARTIFACTORY_TOKEN }}
-          ARTIFACTORY_USER: ${{ secrets.ARTIFACTORY_USER }}
-          CIRCLE_TOKEN: ${{ secrets.CIRCLE_TOKEN }}
       - name: Upload artifacts to actions workflow
         uses: actions/upload-artifact@v2
         with:
@@ -51,7 +28,4 @@ jobs:
             ${{ github.workspace }}/dist/*.zip
             ${{ github.workspace }}/dist/*.sig
             ${{ github.workspace }}/dist/*SHA256
-      - name: Run clamAV antivirus scanner
-        run: sudo clamscan ${{ github.workspace }}/dist/
-      - name: Run maldet malware scanner
-        run: sudo maldet -a ${{ github.workspace }}/dist/
+

--- a/build.goreleaser.yml
+++ b/build.goreleaser.yml
@@ -1,0 +1,30 @@
+before:
+  hooks:
+    - go test ./...
+
+builds:
+  - mod_timestamp: '{{ .CommitTimestamp }}'
+    targets:
+      - linux_386
+      - linux_amd64
+      - darwin_amd64
+      - windows_386
+      - windows_amd64
+    dir: ./cmd/inclusify/
+    flags:
+      - -trimpath
+    ldflags:
+      - -X main.GitCommit={{ .Commit }}
+
+archives:
+  - format: zip
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    files: 
+      - none*
+
+checksum:
+  name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
+  algorithm: sha256
+
+changelog:
+  skip: true

--- a/build.goreleaser.yml
+++ b/build.goreleaser.yml
@@ -18,12 +18,12 @@ builds:
 
 archives:
   - format: zip
-    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    name_template: "{{ .ProjectName }}_{{ .ShortCommit }}_{{ .Os }}_{{ .Arch }}"
     files: 
       - none*
 
 checksum:
-  name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
+  name_template: '{{ .ProjectName }}_{{ .ShortCommit }}_SHA256SUMS'
   algorithm: sha256
 
 changelog:

--- a/release.goreleaser.yml
+++ b/release.goreleaser.yml
@@ -3,6 +3,7 @@ before:
     - go test ./...
 
 builds:
+  # Build, sign, and notarize the darwin and windows packages
   - id: signable
     mod_timestamp: '{{ .CommitTimestamp }}'
     targets:
@@ -23,6 +24,7 @@ builds:
       - -trimpath
     ldflags:
       - -X main.GitCommit={{ .Commit }}
+  # Build the linux packages
   - mod_timestamp: '{{ .CommitTimestamp }}'
     targets:
       - linux_386

--- a/release.goreleaser.yml
+++ b/release.goreleaser.yml
@@ -22,7 +22,7 @@ builds:
     flags:
       - -trimpath
     ldflags:
-      - '-X "main.GitCommit=$(git rev-parse HEAD)"'
+      - -X main.GitCommit={{ .Commit }}
   - mod_timestamp: '{{ .CommitTimestamp }}'
     targets:
       - linux_386
@@ -31,7 +31,7 @@ builds:
     flags:
       - -trimpath
     ldflags:
-      - '-X "main.GitCommit=$(git rev-parse HEAD)"'
+      - -X main.GitCommit={{ .Commit }}
 
 archives:
   - format: zip


### PR DESCRIPTION
- Run a basic build in github actions on branch pushes 
- Use the full commit in the build -X flag
