### PR TITLE
Switch to dockerhub mirror

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ references:
   images: 
     go: &GOLANG_IMAGE cimg/go:1.15.2
     base: &CI_BASE cimg/base:2020.09
-    lint: &GOLANG_LINTER_IMAGE golangci/golangci-lint:v1.28.1-alpine
+    lint: &GOLANG_LINTER_IMAGE docker.mirror.hashicorp.services/golangci/golangci-lint:v1.28.1-alpine
 
 orbs:
   codecov: codecov/codecov@1.1.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,8 +2,8 @@ version: 2.1
 
 references:
   images: 
-    go: &GOLANG_IMAGE cimg/go:1.15.2
-    base: &CI_BASE cimg/base:2020.09
+    go: &GOLANG_IMAGE docker.mirror.hashicorp.services/cimg/go:1.15.2
+    base: &CI_BASE docker.mirror.hashicorp.services/cimg/base:2020.09
     lint: &GOLANG_LINTER_IMAGE docker.mirror.hashicorp.services/golangci/golangci-lint:v1.28.1-alpine
 
 orbs:
@@ -55,7 +55,6 @@ jobs:
       - run:
           name: Docker Build
           command: |
-            export DOCKER_BUILDKIT=1
             docker build --progress=plain \
               --tag "${CIRCLE_WORKFLOW_ID}" \
               --file build/package/docker/Dockerfile \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,6 @@
 ### Artifacts are uploaded to GitHub to help with debugging.
 ### The GitHub release step performs the actions outlined in build.goreleaser.yml. 
 
-
 name: Build
 
 on:

--- a/build/package/docker/Dockerfile
+++ b/build/package/docker/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:experimental
-FROM golang:1.15 as builder
+FROM docker.mirror.hashicorp.services/golang:1.15 as builder
 
 ENV GOBIN=/go/bin
 ENV CGO_ENABLED=0
@@ -17,7 +17,7 @@ RUN go mod download
 COPY ./ .
 RUN go build -ldflags "" -o inclusify ./cmd/inclusify
 
-FROM alpine:3.12
+FROM docker.mirror.hashicorp.services/alpine:3.12
 RUN apk add --no-cache ca-certificates
 WORKDIR /
 COPY --from=builder \


### PR DESCRIPTION
Instead of using dockerhub (which will enforce rate limiting on anonymous image pulls starting Nov 1st), we're moving projects to our mirror at `docker.mirror.hashicorp.services`. circleci/cimg images are excluded.