### PR TITLE
use local gitconfig author for commit

### DIFF
--- a/pkg/files/updateRefs.go
+++ b/pkg/files/updateRefs.go
@@ -12,7 +12,6 @@ import (
 	"github.com/dchest/uniuri"
 	git "github.com/go-git/go-git/v5"
 	plumbing "github.com/go-git/go-git/v5/plumbing"
-	object "github.com/go-git/go-git/v5/plumbing/object"
 	http "github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/google/go-github/v32/github"
 
@@ -123,11 +122,7 @@ func GitPush(c *UpdateRefsCommand, tmpBranch string, repo *git.Repository, dir s
 
 	c.Config.Logger.Info("Committing changes")
 	commitMsg := fmt.Sprintf("Update references from %s to %s", c.Config.Base, c.Config.Target)
-	commitSha, err := worktree.Commit(commitMsg, &git.CommitOptions{
-		Author: &object.Signature{
-			When: time.Now(),
-		},
-	})
+	commitSha, err := worktree.Commit(commitMsg, &git.CommitOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to commit changes: %w", err)
 	}


### PR DESCRIPTION
The commit when updating references in a repo was created without setting an author name/email which made the commit show up as an `unknown` user. For projects with CLA, this will mean that the user is not and cannot sign the CLA and hence can never pass the CLA check. By [default](https://github.com/go-git/go-git/blob/v5.2.0/options.go#L406-L408), the `Author` field of the `CommitOptions` struct will use whatever is locally on your machine which should be an actual user. 

This should have no effect on `INCLUSIFY_TOKEN` as that is the token that allows pushing to GitHub and is unrelated to the `git commit` action. 